### PR TITLE
Added an argument to _active_installs hook

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -461,7 +461,7 @@ function parse_plugin_data($identifier, $endpoint, $request, $content) {
 	// Plugin release date; ie, 2019-12-16 15:02:08
 	$data['added']           = $endpoint[0]->post_date;
 	// Active installs; filterable since active installs aren't counted.
-	$data['active_installs'] = apply_filters(PLUGIN_PREFIX.'_'.$identifier.'_active_installs', 0);
+	$data['active_installs'] = apply_filters(PLUGIN_PREFIX.'_'.$identifier.'_active_installs', 0, $identifier);
 	if (empty($data['active_installs'])) {
 		unset($data['active_installs']);
 	}


### PR DESCRIPTION
Adding an argument (that is the plugin identifier) allows to write only one function to hook to every plugin. 
This way the function handling active_installs know for which plugin is working.